### PR TITLE
Make the workflow work

### DIFF
--- a/experimental_scripts/balancing_targets.py
+++ b/experimental_scripts/balancing_targets.py
@@ -3,18 +3,21 @@ import pandas as pd
 import glob
 import random
 import argparse
+import shutil
 
 parser = argparse.ArgumentParser(description = 'Balance files with many binders')
-parser.add_argument('filename')
-parser.add_argument('output_folder')
+parser.add_argument('--dbfile')
+parser.add_argument('--infile')
+parser.add_argument('--outfile')
+parser.add_argument('--nonbinders-dir')
 args = parser.parse_args()
 
-df_0 = pd.read_csv('database', delimiter = '\t', lineterminator = '\n', header = 0 )
-os.chdir(args.output_folder)
-with open(args.filename, 'r') as file:
+df_0 = pd.read_csv(args.dbfile, delimiter = '\t', lineterminator = '\n', header = 0 )
+
+with open(args.infile, 'r') as infile:
     L0 = []
     L1 = []
-    df_1 = pd.read_csv(file, delim_whitespace = True, lineterminator = '\n', header = 0)
+    df_1 = pd.read_csv(infile, delim_whitespace = True, lineterminator = '\n', header = 0)
     L_nb = list(df_1.iloc[:,0])
     zero_counter = 0
     one_counter = 0
@@ -26,7 +29,9 @@ with open(args.filename, 'r') as file:
     dif = one_counter - zero_counter
     if dif < 0:
         if one_counter == 0:
-            os.rename('./' + args.filename, './only_non_binders/' + args.filename)
+            if not os.path.isdir(args.nonbinders_dir):
+                os.makedirs(args.nonbinders_dir)
+            shutil.copyfile(args.infile, os.path.join(args.nonbinders_dir, os.path.basename(args.infile)))
         else:
             nonbinders = one_counter
             for j in range(0, df_1.shape[0]):
@@ -43,14 +48,14 @@ with open(args.filename, 'r') as file:
                     L0.append(df_1.iloc[k,1])
                     L0.append('\n')
                     nonbinders -= 1
-            with open(args.filename.replace('.json', '') + '_balanced.json', 'w') as outp:
+            with open(args.outfile, 'w') as outp:
                 outp.write('SMILES' + '\t' + 'FLAG' + '\n')
                 for m in L0:
                     outp.write(str(m))
                 for n in L1:
-                    outp.write(str(n))        
+                    outp.write(str(n))
     elif dif >0:
-        with open(args.filename.replace('.json', '') + '_balanced.json', 'w') as f:
+        with open(args.outfile, 'w') as f:
             f.write('SMILES')
             f.write('\t')
             f.write('FLAG')
@@ -65,28 +70,28 @@ with open(args.filename, 'r') as file:
             if df_0.iloc[z,1] not in L_nb:
                 if df_0.iloc[z,2] == 'IC50' and df_0.iloc[z,3]>10000:
                     dif += -1
-                    with open(args.filename.replace('.json', '') + '_balanced.json', 'a') as f:
+                    with open(args.outfile, 'a') as f:
                         f.write(df_0.iloc[z,1])
                         f.write('\t')
                         f.write(str(0))
                         f.write('\n')
                 elif df_0.iloc[z,2] == 'Ki' and df_0.iloc[z,3]>5000:
                     dif += -1
-                    with open(args.filename.replace('.json', '') + '_balanced.json', 'a') as f:
+                    with open(args.outfile, 'a') as f:
                         f.write(df_0.iloc[z,1])
                         f.write('\t')
                         f.write(str(0))
                         f.write('\n')
                 elif df_0.iloc[z,2] == 'Kd' and df_0.iloc[z,3]>5000:
                     dif += -1
-                    with open(args.filename.replace('.json', '') + '_balanced.json', 'a') as f:
+                    with open(args.outfile, 'a') as f:
                         f.write(df_0.iloc[z,1])
                         f.write('\t')
                         f.write(str(0))
                         f.write('\n')
                 elif df_0.iloc[z,2] == 'EC50' and df_0.iloc[z,3]>10000:
                     dif += -1
-                    with open(args.filename.replace('.json', '') + '_balanced.json', 'a') as f:
+                    with open(args.outfile, 'a') as f:
                         f.write(df_0.iloc[z,1])
                         f.write('\t')
                         f.write(str(0))

--- a/experimental_scripts/db_targets.py
+++ b/experimental_scripts/db_targets.py
@@ -4,21 +4,25 @@ import os
 
 #"--input", type = file, help = "input filename"
 parser = argparse.ArgumentParser(description = 'Process the Chembl database')
-parser.add_argument('filename', help = 'The database to take the targets from')
-parser.add_argument('output_folder', help = 'The folder to produce the target files')
+parser.add_argument('--database', help = 'The database to take the targets from')
+parser.add_argument('--outdir', help = 'The folder to produce the target files')
+
 args = parser.parse_args()
-with open(args.filename, 'r') as file:
-    df = pd.read_csv(file, delimiter = '\t', lineterminator = '\n', header = 0)
+with open(args.database, 'r') as dbfile:
+    df = pd.read_csv(dbfile, delimiter = '\t', lineterminator = '\n', header = 0)
     D={}
+
     for i in range(0, df.shape[0]):
         df.iloc[i, 0] = df.iloc[i, 0].replace('/','-')
         df.iloc[i, 0] = df.iloc[i, 0].replace(' ','_')
         df.iloc[i, 0] = df.iloc[i, 0].replace('(','_')
         df.iloc[i, 0] = df.iloc[i, 0].replace(')','_')
         df.iloc[i, 0] = df.iloc[i, 0].replace("'",'')
+
     for i in range(0, df.shape[0]):
         if df.iloc[i, 0] not in D:
             D[df.iloc[i, 0]] = []
+
     for j in range(0, df.shape[0]):
         D.setdefault(df.iloc[j,0],[]).append(df.iloc[j,1]+'\t')
         if df.iloc[j,2]=='IC50' and df.iloc[j,3]>10000:
@@ -37,10 +41,11 @@ with open(args.filename, 'r') as file:
             D.setdefault(df.iloc[j,0],[]).append('0\n')
         elif df.iloc[j,2]=='EC50' and df.iloc[j,3]<=10000:
             D.setdefault(df.iloc[j,0],[]).append('1\n')
-    os.mkdir(args.output_folder)
-    os.chdir(args.output_folder)
+
+    if not os.path.isdir(args.outdir):
+        os.makedirs(args.outdir)
+
     for key,value in D.items():
-        with open(key + '.json', 'w+') as f:
-            f.write('SMILES' + '\t' + 'FLAG' + '\n')
-            f.write(''.join(value))
-os.mkdir('only_non_binders')
+        with open(os.path.join(args.outdir, key + '.tsv'), 'w+') as outfile:
+            outfile.write('SMILES' + '\t' + 'FLAG' + '\n')
+            outfile.write(''.join(value))

--- a/experimental_scripts/workflow.go
+++ b/experimental_scripts/workflow.go
@@ -13,13 +13,15 @@ func main() {
 	createDatasets.SetOut("outdir", "targets_folder")
 
 	// Glob target datasets
-	globDatasets := spc.NewFileGlobberDependent(wf, "glob_datasets", "./targets_folder/*.json")
+	globDatasets := spc.NewFileGlobberDependent(wf, "glob_datasets", "./targets_folder/*.tsv")
 	globDatasets.InDependency().From(createDatasets.Out("outdir"))
 
 	// Balance datasets
-	balanceDatasets := wf.NewProc("balance_datasets", "python3 ../balancing_targets.py {i:inpfiles} ../targets_folder; echo 'done' > {o:done2file}")
-	balanceDatasets.In("inpfiles").From(globDatasets.Out())
-	balanceDatasets.SetOut("done2file", "{i:inpfiles|%.json}.done")
+	balanceDatasets := wf.NewProc("balance_datasets", "python3 ../balancing_targets.py --dbfile=../database --infile={i:infile} --outfile={o:outfile} --nonbinders-dir={o:nonbinders_dir}")
+	balanceDatasets.In("infile").From(globDatasets.Out())
+	balanceDatasets.SetOut("outfile", "balanced_targets_folder/{i:infile|basename|%.tsv}.balanced.tsv")
+	balanceDatasets.SetOut("nonbinders_dir", "only_non_binders")
 
+	// Run workflow
 	wf.Run()
 }

--- a/experimental_scripts/workflow.go
+++ b/experimental_scripts/workflow.go
@@ -10,17 +10,17 @@ func main() {
 
 	// Create target datasets
 	createDatasets := wf.NewProc("create_datasets", "python3 ../db_targets.py --database=../database --outdir={o:outdir}")
-	createDatasets.SetOut("outdir", "targets_folder")
+	createDatasets.SetOut("outdir", "all_targets")
 
 	// Glob target datasets
-	globDatasets := spc.NewFileGlobberDependent(wf, "glob_datasets", "./targets_folder/*.tsv")
+	globDatasets := spc.NewFileGlobberDependent(wf, "glob_datasets", "./all_targets/*.tsv")
 	globDatasets.InDependency().From(createDatasets.Out("outdir"))
 
 	// Balance datasets
 	balanceDatasets := wf.NewProc("balance_datasets", "python3 ../balancing_targets.py --dbfile=../database --infile={i:infile} --outfile={o:outfile} --nonbinders-dir={o:nonbinders_dir}")
 	balanceDatasets.In("infile").From(globDatasets.Out())
-	balanceDatasets.SetOut("outfile", "balanced_targets_folder/{i:infile|basename|%.tsv}.balanced.tsv")
-	balanceDatasets.SetOut("nonbinders_dir", "only_non_binders")
+	balanceDatasets.SetOut("outfile", "balanced_targets/{i:infile|basename|%.tsv}.balanced.tsv")
+	balanceDatasets.SetOut("nonbinders_dir", "only_non_binding_targets")
 
 	// Run workflow
 	wf.Run()

--- a/experimental_scripts/workflow.go
+++ b/experimental_scripts/workflow.go
@@ -9,12 +9,12 @@ func main() {
 	wf := sp.NewWorkflow("DS_CPSign", 4)
 
 	// Create target datasets
-	createDatasets := wf.NewProc("create_datasets", "python3 ../db_targets.py ../database ../targets_folder; echo 'done' > {o:donefile}")
-	createDatasets.SetOut("donefile", "targets_folder.done")
+	createDatasets := wf.NewProc("create_datasets", "python3 ../db_targets.py --database=../database --outdir={o:outdir}")
+	createDatasets.SetOut("outdir", "targets_folder")
 
 	// Glob target datasets
 	globDatasets := spc.NewFileGlobberDependent(wf, "glob_datasets", "./targets_folder/*.json")
-	globDatasets.InDependency().From(createDatasets.Out("donefile"))
+	globDatasets.InDependency().From(createDatasets.Out("outdir"))
 
 	// Balance datasets
 	balanceDatasets := wf.NewProc("balance_datasets", "python3 ../balancing_targets.py {i:inpfiles} ../targets_folder; echo 'done' > {o:done2file}")

--- a/experimental_scripts/workflow.go
+++ b/experimental_scripts/workflow.go
@@ -1,23 +1,25 @@
 package main
 
 import (
-		sp "github.com/scipipe/scipipe"
-		spc "github.com/scipipe/scipipe/components"
-		)
-		
+	sp "github.com/scipipe/scipipe"
+	spc "github.com/scipipe/scipipe/components"
+)
+
 func main() {
+	wf := sp.NewWorkflow("DS_CPSign", 4)
 
-wf := sp.NewWorkflow("DS_CPSign", 4)
+	// Create target datasets
+	pythonProc1 := wf.NewProc("Proc1", "python3 ../db_targets.py ../database ../targets_folder; echo 'done' > {o:donefile}")
+	pythonProc1.SetOut("donefile", "log1")
 
-pythonProc1 := wf.NewProc("Proc1", "python3 ../db_targets.py ../database ../targets_folder; echo 'done' > {o:donefile}")
-targetsDirectory := spc.NewFileGlobberDependent(wf, "Targets_in_Dir", "./targets_folder/*.json")
-pythonProc2 := wf.NewProc("Proc2", "python3 ../balancing_targets.py {i:inpfiles} ../targets_folder; echo 'done' > {o:done2file}")
+	// Glob target datasets
+	targetsDirectory := spc.NewFileGlobberDependent(wf, "Targets_in_Dir", "./targets_folder/*.json")
+	targetsDirectory.InDependency().From(pythonProc1.Out("donefile"))
 
+	// Balance datasets
+	pythonProc2 := wf.NewProc("Proc2", "python3 ../balancing_targets.py {i:inpfiles} ../targets_folder; echo 'done' > {o:done2file}")
+	pythonProc2.In("inpfiles").From(targetsDirectory.Out())
+	pythonProc2.SetOut("done2file", "{i:inpfiles|%.json}_done")
 
-pythonProc1.SetOut("donefile", "log1")
-targetsDirectory.InDependency().From(pythonProc1.Out("donefile"))
-pythonProc2.In("inpfiles").From(targetsDirectory.Out())
-pythonProc2.SetOut("done2file", "{i:inpfiles|%.json}_done")
-
-wf.Run()
+	wf.Run()
 }


### PR DESCRIPTION
Hi @PaschalisAthan,

I have managed to get the workflow running now. There are a lot of things going on though. Perhaps too many things to easily spot in the diffs.

Firstly: Make sure to update scipipe before running this, because there is one small addition I added, and released in a new version, [0.8.3](https://github.com/scipipe/scipipe/releases/tag/v0.8.3).

[Check here](https://github.com/PaschalisAthan/Master_Thesis/pull/2/files) to view all the changes I did to make this work.

### Some overall comments about these changes:

- There were a number of places where the inut and output paths were not taken as arguments in the script, but were instead created inside the script.
- The `balancing_targets.py` script does not need to take a folder as input or output. It can instead operate by taking an explicicit inputfile, outputfile, the path to the database file, and the directory for the nonbinders. These are now added as arguments.
- Adding the arguments with two dashes before, means you will need to specify the name of them when calling the script (so, `myscript.py --input=infile.txt --output=outfiletxt` etc). This is a good thing, since this drastically decreases the risk to accidentally overwrite existing files by mixing up the order of input and output files.
- Also were multiple `with open(..., 'w')`, where this could be done once, since only one output file was created.
- I have also created a bit clearer names of variables etc in the workflow file, to make it easier to follow.
- I realized one thing: One should not use `;` to separate multiple commands in the workflow, as I suggested earlier, since then there will be no error message if the first command fails, but the second one succeeds. Instead, use `&&`. This will make sure the whole set of commands fails properly if any of them fails. Luckily though, with the latest changes, we don't need the donefiles, since we can just use the created directories, since they are also created as proper scipipe outputs.

There is one more thing that I suggest you fix, but I did not want to mess up the diff with that, since it is different from getting the workflow to work: In `balanced_targets.py`, you are opening the output file multiple times, although it is the same file. It can instead be done only one time, close to where you open the infile, by starting the script with:

```python
with open(args.infile ....) as infile:
    with open(args.outfile, ...) as outfile:
        # ... python code here ...
```

Let me know if anything is unclear!