### PR TITLE
Add new combinator process to create combinations of the globbed files

### DIFF
--- a/SciPipe/Uncomplete_scripts/workflow_predict.go
+++ b/SciPipe/Uncomplete_scripts/workflow_predict.go
@@ -14,6 +14,12 @@ func main() {
 	// Glob Files to Predict
 	globFilesToPredict := spc.NewFileGlobber(wf, "glob_file_to_predict", "./files_toPredict/*.json")
 
+	// Add a combinator that ensures all combinations of the files on the
+	// incoming streams are created and sent to the downstream process
+	combineGlobbers := spc.NewFileCombinator(wf, "combine_globbers")
+	combineGlobbers.In("models").From(globTrainedModels.Out())
+	combineGlobbers.In("datasets").From(globFilesToPredict.Out())
+
 	// Predict
 	predict := wf.NewProc("Predict", `java -jar /Users/paat9648/Desktop/Project/Go/src/cpsign-0.7.8.jar predict \
 												--license /Users/paat9648/Desktop/Project/Go/src/cpsign0x-std-building.license \
@@ -23,12 +29,11 @@ func main() {
 												--output {o:resultFile} \
 												--logfile {o:logs} 2> {o:statusfile} && echo 'Succeeded' > {o:statusfile}; echo 'Foo'`)
 
-	predict.In("trainedmodel").From(globTrainedModels.Out())
-	predict.In("predictFile").From(globFilesToPredict.Out())
+	predict.In("trainedmodel").From(combineGlobbers.Out("models"))
+	predict.In("predictFile").From(combineGlobbers.Out("datasets"))
 	predict.SetOut("resultFile", "results/{i:predictFile|basename|%_smiles.json}/{i:trainedmodel|basename|%.cpsign}")
 	predict.SetOut("logs", "logs/{i:predictFile|basename|%_smiles.json}/{i:trainedmodel|basename|%.cpsign}.log")
 	predict.SetOut("statusfile", "process/{i:predictFile|basename|%_smiles.json}/{i:trainedmodel|basename|%.cpsign}.done")
-
 
 	//Run workflow
 	wf.Run()


### PR DESCRIPTION
Hi Paschalis, 

Now if you upgrade scipipe to 0.9.1 with:

```bash
go get -u github.com/scipipe/scipipe/...
```
... and apply this pull request, the predict process should execute the right number of times.

I created the new component [FileCombinator](https://godoc.org/github.com/scipipe/scipipe/components#FileCombinator) ... for which there is a really short documentation page up [here](http://scipipe.org/howtos/file_combinations/).